### PR TITLE
fix: OSError read should return bytes

### DIFF
--- a/gs_chunked_io/reader.py
+++ b/gs_chunked_io/reader.py
@@ -44,7 +44,7 @@ class Reader(io.IOBase):
 
         ret_data = self._buffer[:size]
         del self._buffer[:size]
-        return ret_data
+        return bytes(ret_data)
 
     def readinto(self, buff) -> int:
         d = self.read(len(buff))
@@ -99,7 +99,7 @@ class AsyncReader(Reader):
         self._wait_for_buffer_and_remove_complete_futures(size)
         ret_data = self._buffer[:size]
         del self._buffer[:size]
-        return ret_data
+        return bytes(ret_data)
 
     def for_each_chunk(self):
         while True:

--- a/gs_chunked_io/reader.py
+++ b/gs_chunked_io/reader.py
@@ -42,9 +42,9 @@ class Reader(io.IOBase):
             self._buffer += self.fetch_chunk(chunk_number)
         self._unfetched_chunks = self._unfetched_chunks[number_of_chunks_to_fetch:]
 
-        ret_data = self._buffer[:size]
+        ret_data = bytes(memoryview(self._buffer)[:size])
         del self._buffer[:size]
-        return bytes(ret_data)
+        return ret_data
 
     def readinto(self, buff) -> int:
         d = self.read(len(buff))
@@ -97,9 +97,9 @@ class AsyncReader(Reader):
             size = self.blob.size
         self._fetch_async(size)
         self._wait_for_buffer_and_remove_complete_futures(size)
-        ret_data = self._buffer[:size]
+        ret_data = bytes(memoryview(self._buffer)[:size])
         del self._buffer[:size]
-        return bytes(ret_data)
+        return ret_data
 
     def for_each_chunk(self):
         while True:


### PR DESCRIPTION
Thanks for the helpful library. I tried it out and got an `OSError` about `read` needing to return `bytes` instead of `bytesarray`. It looks like this is because the `pathlib.Path` asserts on the return type from read internally. Besides fixing the error, this is more consistent with your type annotations. 